### PR TITLE
downgrading torchmetrics to account for data_range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ repository = "https://github.com/BrainLesion/inpainting"
 #documentation = ""
 
 [tool.poetry.dependencies]
-torchmetrics = ">=1.1.2"
+torchmetrics = ">=1.1.2,<1.8.0"
 python = ">=3.10"
 nibabel = ">=3.0"
 numpy = ">=1.25"


### PR DESCRIPTION
quick and dirty fix for data_range argument:
accounting for:
https://github.com/Lightning-AI/torchmetrics/releases/tag/v1.8.0

https://github.com/Lightning-AI/torchmetrics/commit/ea026ae235a396a1933d2d750c3f1919edbabf0a