### PR TITLE
Fixed PeakSignalNoiseRatio() initialization for torchmetrics 1.8.1

### DIFF
--- a/inpainting/challenge_metrics_2023.py
+++ b/inpainting/challenge_metrics_2023.py
@@ -128,22 +128,16 @@ def _peak_signal_noise_ratio(
         epsilon (float, optional): If not None, this epsilon is added to the denominator of the fraction to avoid infinity as output. Defaults to None.
     """
 
+    # Calculate data_range from data it not given
+    if data_range == None:
+        data_range = (torch.min(target), torch.max(target))
+
     if epsilon == None:
-        psnr = (
-            PeakSignalNoiseRatio()
-            if data_range == None
-            else PeakSignalNoiseRatio(data_range=data_range[1] - data_range[0])
-        )
+        psnr = PeakSignalNoiseRatio(data_range=data_range)
         return psnr(preds=prediction, target=target)
     else:  # implementation of PSNR that does not give 'inf'/'nan' when 'mse==0'
         mse = _mean_squared_error(target=target, prediction=prediction)
-        if data_range == None:  # compute data_range like torchmetrics if not given
-            min_v = (
-                0 if torch.min(target) > 0 else torch.min(target)
-            )  # look at this line
-            max_v = torch.max(target)
-        else:
-            min_v, max_v = data_range
+        min_v, max_v = data_range
         return 10.0 * torch.log10(((max_v - min_v) ** 2) / (mse + epsilon))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ repository = "https://github.com/BrainLesion/inpainting"
 #documentation = ""
 
 [tool.poetry.dependencies]
-torchmetrics = ">=1.1.2,<1.8.0"
+torchmetrics = ">=1.1.2"
 python = ">=3.10"
 nibabel = ">=3.0"
 numpy = ">=1.25"


### PR DESCRIPTION
Changed __peak_signal_noise_ratio()_ so it initializes `PeakSignalNoiseRatio()` always with `data_range` (which is no longer optional in **torchmetrics 1.8.1**).

- For the case `data_range==None` and `epsilon==None`, this had caused an **error**, which is does not anymore without changing the functionality of the code.

- For the case `data_range==None` and `epsilon!=None`, the logic changed slightly, as data_range is now also computed as per the new torchmetrics standard (properly `max-min`, not doing the weird cutoff at 0 of the minimum). I hope/assume this does not break downward compatibility. It overall makes the metrics computation more correct and consistent. 
